### PR TITLE
feat: read attributes from root node of XML documents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
     <groupId>com.ibm.eventstreams.kafkaconnect.plugins</groupId>
     <artifactId>kafka-connect-xml-converter</artifactId>
     <description>Kafka Connect plugins for processing XML data</description>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
-            <version>3.5.1</version>
+            <version>3.7.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.9</version>
+            <version>2.0.16</version>
         </dependency>
 
         <dependency>
@@ -49,31 +49,31 @@
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
-            <version>2.9.1</version>
+            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-matchers</artifactId>
-            <version>2.9.1</version>
+            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-json</artifactId>
-            <version>3.6.0</version>
+            <version>3.7.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.3</version>
+            <version>2.17.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-nop</artifactId>
-            <version>2.0.9</version>
+            <version>2.0.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.13.0</version>
                 <inherited>true</inherited>
                 <configuration>
                     <source>17</source>
@@ -103,7 +103,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.7.1</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -122,7 +122,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.10</version>
+                <version>0.8.12</version>
                 <configuration>
                     <excludes>
                         <!-- requires a queue manager to test, so excluded from unit test coverage reports -->

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlConverterSinkTest.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlConverterSinkTest.java
@@ -88,7 +88,10 @@ public class XmlConverterSinkTest {
             { "038", true, true, true },
 //            { "039", true, true, true },
             { "040", true, true, true },
-            { "047", false, true, false }
+            { "047", false, true, false },
+            { "052", false, false, false },
+            { "053", false, false, false },
+            { "054", false, true, false }
         });
     }
 

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlTransformationStringTest.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlTransformationStringTest.java
@@ -75,7 +75,10 @@ public class XmlTransformationStringTest {
             { "025", true, true },
             { "027", false, true },
             { "028", true, true },
-            { "037", false, false }
+            { "037", false, false },
+            { "052", true, true },
+            { "053", true, true },
+            { "054", false, true }
         });
     }
 

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/engines/XStreamMapConverterTest.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/engines/XStreamMapConverterTest.java
@@ -79,10 +79,13 @@ public class XStreamMapConverterTest {
 //            { "034", true },
 //            { "035", true },
 //            { "036", true },
-            { "037", true }
+            { "037", true },
 //            { "038", true },
 //            { "039", true },
 //            { "040", true },
+            { "052", false },
+            { "053", false },
+            { "054", true }
         });
     }
 

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/engines/XStreamStructConverterTest.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/engines/XStreamStructConverterTest.java
@@ -85,7 +85,10 @@ public class XStreamStructConverterTest {
             { "040", false },
             { "042", false },
             { "043", false },
-            { "044", false }
+            { "044", false },
+            { "052", false },
+            { "053", false },
+            { "054", false }
         });
     }
 

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/engines/XmlToStructTest.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/engines/XmlToStructTest.java
@@ -86,7 +86,10 @@ public class XmlToStructTest {
             { "041", true, true },
             { "042", true, true },
             { "043", true, false },
-            { "047", false, false }
+            { "047", false, false },
+            { "052", false, false },
+            { "053", false, false },
+            { "054", true, false }
         });
     }
 

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/engines/XsdToSchemaTest.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/engines/XsdToSchemaTest.java
@@ -79,7 +79,10 @@ public class XsdToSchemaTest {
             { "037", false },
             { "038", true },
             { "040", true },
-            { "047", false }
+            { "047", false },
+            { "052", false },
+            { "053", false },
+            { "054", false }
         });
     }
 

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/testutils/MapGenerators.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/testutils/MapGenerators.java
@@ -116,7 +116,7 @@ public class MapGenerators {
             case "005":
                 value.put("entry", ListGenerators.get(testCaseId));
                 break;
-            case "006":
+            case "006": {
                 final Map<String, Object> test1 = new LinkedHashMap<>();
                 test1.put("test2", "one");
                 final Map<String, Object> test5_0 = new LinkedHashMap<>();
@@ -137,6 +137,7 @@ public class MapGenerators {
                 value.put("test1", test1);
                 value.put("outer", outer);
                 break;
+            }
             case "007":
                 value.put("type0", "string");
                 value.put("type1", "https://www.ibm.com");
@@ -968,6 +969,65 @@ public class MapGenerators {
                 value.put("map-of-arrays", mapOfArrays);
                 break;
             }
+            case "052": {
+                value.put("myattr1", "testing");
+                value.put("myattr2", 123);
+                value.put("test1", "one");
+                value.put("test2", "two");
+                break;
+            }
+            case "053": {
+                value.put("myattr1", "testing");
+                value.put("myattr2", 123);
+                value.put("myattr3", false);
+
+                Map<String, Object> test1 = new LinkedHashMap<>();
+                test1.put("myattr4", "inner");
+                test1.put("entry", "one");
+                value.put("test1", test1);
+
+                Map<String, Object> test2 = new LinkedHashMap<>();
+                test2.put("test2a", "alpha");
+                Map<String, Object> test2b = new LinkedHashMap<>();
+                test2b.put("myattr5", "deepinner");
+                test2b.put("entry", "beta");
+                test2.put("test2b", test2b);
+                value.put("test2", test2);
+
+                Map<String, Object> test3 = new LinkedHashMap<>();
+                test3.put("myattr6", "middle");
+                test3.put("test3a", 333);
+                value.put("test3", test3);
+
+                value.put("test4", "four");
+                break;
+            }
+            case "054": {
+                Map<String, Object> transaccion = new LinkedHashMap<>();
+                transaccion.put("id", "PE80");
+                transaccion.put("tecla", "00");
+                transaccion.put("numclie", 51372133);
+                Map<String, Object> datos = new LinkedHashMap<>();
+                datos.put("transaccion", transaccion);
+                Map<String, Object> xmlentrada = new LinkedHashMap<>();
+                xmlentrada.put("datos", datos);
+                Map<String, Object> data = new LinkedHashMap<>();
+                data.put("xml-entrada", xmlentrada);
+                data.put("trama-entrada", "longer test string");
+                data.put("mq-server", "MQ : SPIAWT99;;;SPIA.QC.QZT1;SPIA.QP.OUT");
+                data.put("direccion-IP", "17.127.22.33");
+                data.put("nombre-servidor", "Qpbxiaa");
+                data.put("canal", "ABC");
+
+                value.put("date", "2024-08-06 12:32:04");
+                value.put("cr", 2246);
+                value.put("tx", "PE23");
+                value.put("user", "01888329");
+                value.put("estatus-tx", 1);
+                value.put("version", "7.0.1001.2");
+                value.put("data", data);
+                break;
+            }
         }
         return value;
     }
@@ -1587,6 +1647,34 @@ public class MapGenerators {
                 value.put("multipleBytes", List.of(30, 31, 32, 33, 34));
                 value.put("multipleUnsignedBytes", List.of(60, 61, 62));
                 value.put("base64EncodedBytes", "U2VjcmV0IG1lc3NhZ2U=");
+                return value;
+            }
+            case "054": {
+                final Map<String, Object> value = new LinkedHashMap<>();
+
+                Map<String, Object> transaccion = new LinkedHashMap<>();
+                transaccion.put("id", "PE80");
+                transaccion.put("tecla", 0);
+                transaccion.put("numclie", 51372133);
+                Map<String, Object> datos = new LinkedHashMap<>();
+                datos.put("transaccion", transaccion);
+                Map<String, Object> xmlentrada = new LinkedHashMap<>();
+                xmlentrada.put("datos", datos);
+                Map<String, Object> data = new LinkedHashMap<>();
+                data.put("xml-entrada", xmlentrada);
+                data.put("trama-entrada", "longer test string");
+                data.put("mq-server", "MQ : SPIAWT99;;;SPIA.QC.QZT1;SPIA.QP.OUT");
+                data.put("direccion-IP", "17.127.22.33");
+                data.put("nombre-servidor", "Qpbxiaa");
+                data.put("canal", "ABC");
+
+                value.put("date", "2024-08-06 12:32:04");
+                value.put("cr", 2246);
+                value.put("tx", "PE23");
+                value.put("user", 1888329);
+                value.put("estatus-tx", 1);
+                value.put("version", "7.0.1001.2");
+                value.put("data", data);
                 return value;
             }
             default:

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/testutils/StructGenerators.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/testutils/StructGenerators.java
@@ -1682,6 +1682,135 @@ public class StructGenerators {
 
                 return new SchemaAndValue(schema, value);
             }
+            case "052": {
+                final Schema schema = SchemaBuilder.struct()
+                    .name("root")
+                    .field("test1", Schema.STRING_SCHEMA)
+                    .field("test2", Schema.STRING_SCHEMA)
+                    .field("myattr1", Schema.OPTIONAL_STRING_SCHEMA)
+                    .field("myattr2", Schema.OPTIONAL_INT32_SCHEMA)
+                    .build();
+
+                final Struct value = new Struct(schema);
+                value.put("test1", "one");
+                value.put("test2", "two");
+                value.put("myattr1", "testing");
+                value.put("myattr2", 123);
+
+                return new SchemaAndValue(schema, value);
+            }
+            case "053": {
+                final Schema test1Schema = SchemaBuilder.struct()
+                    .field("entry", Schema.STRING_SCHEMA)
+                    .field("myattr4", Schema.OPTIONAL_STRING_SCHEMA)
+                    .build();
+                final Schema test2bSchema = SchemaBuilder.struct()
+                    .field("entry", Schema.STRING_SCHEMA)
+                    .field("myattr5", Schema.STRING_SCHEMA)
+                    .build();
+                final Schema test2Schema = SchemaBuilder.struct()
+                    .field("test2a", Schema.STRING_SCHEMA)
+                    .field("test2b", test2bSchema)
+                    .build();
+                final Schema test3Schema = SchemaBuilder.struct()
+                    .field("test3a", Schema.INT32_SCHEMA)
+                    .field("myattr6", Schema.STRING_SCHEMA)
+                    .build();
+
+                final Schema schema = SchemaBuilder.struct()
+                    .name("root")
+                    .field("test1", test1Schema)
+                    .field("test2", test2Schema)
+                    .field("test3", test3Schema)
+                    .field("test4", Schema.STRING_SCHEMA)
+                    .field("myattr1", Schema.STRING_SCHEMA)
+                    .field("myattr2", Schema.OPTIONAL_INT32_SCHEMA)
+                    .field("myattr3", Schema.BOOLEAN_SCHEMA)
+                    .build();
+
+                final Struct test1 = new Struct(test1Schema);
+                test1.put("myattr4", "inner");
+                test1.put("entry", "one");
+                final Struct test2b = new Struct(test2bSchema);
+                test2b.put("myattr5", "deepinner");
+                test2b.put("entry", "beta");
+                final Struct test2 = new Struct(test2Schema);
+                test2.put("test2a", "alpha");
+                test2.put("test2b", test2b);
+                final Struct test3 = new Struct(test3Schema);
+                test3.put("myattr6", "middle");
+                test3.put("test3a", 333);
+
+                final Struct value = new Struct(schema);
+                value.put("test1", test1);
+                value.put("test2", test2);
+                value.put("test3", test3);
+                value.put("test4", "four");
+                value.put("myattr1", "testing");
+                value.put("myattr2", 123);
+                value.put("myattr3", false);
+
+                return new SchemaAndValue(schema, value);
+            }
+            case "054": {
+                final Schema transaccionSchema = SchemaBuilder.struct()
+                    .field("numclie", Schema.INT32_SCHEMA)
+                    .field("id", Schema.STRING_SCHEMA)
+                    .field("tecla", Schema.STRING_SCHEMA)
+                    .build();
+                final Schema datosSchema = SchemaBuilder.struct()
+                    .field("transaccion", transaccionSchema)
+                    .build();
+                final Schema xmlentradaSchema = SchemaBuilder.struct()
+                    .field("datos", datosSchema)
+                    .build();
+                final Schema dataSchema = SchemaBuilder.struct()
+                    .field("xml-entrada", xmlentradaSchema)
+                    .field("trama-entrada", Schema.STRING_SCHEMA)
+                    .field("mq-server", Schema.STRING_SCHEMA)
+                    .field("direccion-IP", Schema.STRING_SCHEMA)
+                    .field("nombre-servidor", Schema.STRING_SCHEMA)
+                    .field("canal", Schema.STRING_SCHEMA)
+                    .build();
+
+                final Schema schema = SchemaBuilder.struct()
+                    .name("root")
+                    .field("data", dataSchema)
+                    .field("date", Schema.STRING_SCHEMA)
+                    .field("cr", Schema.STRING_SCHEMA)
+                    .field("tx", Schema.STRING_SCHEMA)
+                    .field("user", Schema.STRING_SCHEMA)
+                    .field("estatus-tx", Schema.STRING_SCHEMA)
+                    .field("version", Schema.STRING_SCHEMA)
+                    .build();
+
+                final Struct transaccion = new Struct(transaccionSchema);
+                transaccion.put("id", "PE80");
+                transaccion.put("tecla", "00");
+                transaccion.put("numclie", 51372133);
+                final Struct datos = new Struct(datosSchema);
+                datos.put("transaccion", transaccion);
+                final Struct xmlentrada = new Struct(xmlentradaSchema);
+                xmlentrada.put("datos", datos);
+                final Struct data = new Struct(dataSchema);
+                data.put("xml-entrada", xmlentrada);
+                data.put("trama-entrada", "longer test string");
+                data.put("mq-server", "MQ : SPIAWT99;;;SPIA.QC.QZT1;SPIA.QP.OUT");
+                data.put("direccion-IP", "17.127.22.33");
+                data.put("nombre-servidor", "Qpbxiaa");
+                data.put("canal", "ABC");
+
+                final Struct value = new Struct(schema);
+                value.put("date", "2024-08-06 12:32:04");
+                value.put("cr", "2246");
+                value.put("tx", "PE23");
+                value.put("user", "01888329");
+                value.put("estatus-tx", "1");
+                value.put("version", "7.0.1001.2");
+                value.put("data", data);
+
+                return new SchemaAndValue(schema, value);
+            }
         }
         throw new NotImplementedException("Unrecognised test " + testCaseId);
     }

--- a/src/test/resources/052-combined.xml
+++ b/src/test/resources/052-combined.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="#connectSchema"
+        myattr1="testing" myattr2="123">
+
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" id="connectSchema">
+        <xs:element name="root">
+            <xs:complexType>
+                <xs:sequence>
+                    <xs:element type="xs:string" name="test1"/>
+                    <xs:element type="xs:string" name="test2"/>
+                </xs:sequence>
+                <xs:attribute type="xs:string" name="myattr1"/>
+                <xs:attribute type="xs:integer" name="myattr2"/>
+            </xs:complexType>
+        </xs:element>
+    </xs:schema>
+
+    <test1>one</test1>
+    <test2>two</test2>
+</root>

--- a/src/test/resources/052.xml
+++ b/src/test/resources/052.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root myattr1="testing" myattr2="123">
+    <test1>one</test1>
+    <test2>two</test2>
+</root>

--- a/src/test/resources/052.xsd
+++ b/src/test/resources/052.xsd
@@ -1,0 +1,13 @@
+<?xml version = "1.0"?>
+<xs:schema xmlns:xs = "http://www.w3.org/2001/XMLSchema">
+    <xs:element name="root">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element type="xs:string" name="test1"/>
+                <xs:element type="xs:string" name="test2"/>
+            </xs:sequence>
+            <xs:attribute type="xs:string" name="myattr1"/>
+            <xs:attribute type="xs:integer" name="myattr2"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/src/test/resources/053-combined.xml
+++ b/src/test/resources/053-combined.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="#connectSchema"
+    myattr1="testing" myattr2="123" myattr3="false">
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" id="connectSchema">
+        <xs:element name="root">
+            <xs:complexType>
+                <xs:sequence>
+                    <xs:element name="test1" type="test1"/>
+                    <xs:element name="test2" type="test2"/>
+                    <xs:element name="test3" type="test3"/>
+                    <xs:element name="test4" type="xs:string"/>
+                </xs:sequence>
+                <xs:attribute type="xs:string"  name="myattr1" use="required"/>
+                <xs:attribute type="xs:integer" name="myattr2" use="optional"/>
+                <xs:attribute type="xs:boolean" name="myattr3" use="required"/>
+            </xs:complexType>
+        </xs:element>
+
+        <xs:complexType name="test1">
+            <xs:simpleContent>
+                <xs:extension base="xs:string">
+                    <xs:attribute name="myattr4" type="xs:string" use="optional"/>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+
+        <xs:complexType name="test2">
+            <xs:sequence>
+                <xs:element name="test2a" type="xs:string"/>
+                <xs:element name="test2b" type="test2b"/>
+            </xs:sequence>
+        </xs:complexType>
+
+        <xs:complexType name="test3">
+            <xs:sequence>
+                <xs:element name="test3a" type="xs:integer"/>
+            </xs:sequence>
+            <xs:attribute name="myattr6" type="xs:string" use="required"/>
+        </xs:complexType>
+
+
+        <xs:complexType name="test2b">
+            <xs:simpleContent>
+                <xs:extension base="xs:string">
+                    <xs:attribute name="myattr5" type="xs:string" use="required"/>
+                </xs:extension>
+            </xs:simpleContent>
+        </xs:complexType>
+    </xs:schema>
+
+    <test1 myattr4="inner">one</test1>
+    <test2>
+        <test2a>alpha</test2a>
+        <test2b myattr5="deepinner">beta</test2b>
+    </test2>
+    <test3 myattr6="middle">
+        <test3a>333</test3a>
+    </test3>
+    <test4>four</test4>
+</root>

--- a/src/test/resources/053.xml
+++ b/src/test/resources/053.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root myattr1="testing" myattr2="123" myattr3="false">
+    <test1 myattr4="inner">one</test1>
+    <test2>
+        <test2a>alpha</test2a>
+        <test2b myattr5="deepinner">beta</test2b>
+    </test2>
+    <test3 myattr6="middle">
+        <test3a>333</test3a>
+    </test3>
+    <test4>four</test4>
+</root>

--- a/src/test/resources/053.xsd
+++ b/src/test/resources/053.xsd
@@ -1,0 +1,49 @@
+<?xml version = "1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="root">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="test1" type="test1"/>
+                <xs:element name="test2" type="test2"/>
+                <xs:element name="test3" type="test3"/>
+                <xs:element name="test4" type="xs:string"/>
+            </xs:sequence>
+            <xs:attribute type="xs:string"  name="myattr1" use="required"/>
+            <xs:attribute type="xs:integer" name="myattr2" use="optional"/>
+            <xs:attribute type="xs:boolean" name="myattr3" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="test1">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="myattr4" type="xs:string" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="test2">
+        <xs:sequence>
+            <xs:element name="test2a" type="xs:string"/>
+            <xs:element name="test2b" type="test2b"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="test3">
+        <xs:sequence>
+            <xs:element name="test3a" type="xs:integer"/>
+        </xs:sequence>
+        <xs:attribute name="myattr6" type="xs:string" use="required"/>
+    </xs:complexType>
+
+
+    <xs:complexType name="test2b">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="myattr5" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+
+</xs:schema>

--- a/src/test/resources/054.xml
+++ b/src/test/resources/054.xml
@@ -1,0 +1,16 @@
+<root date="2024-08-06 12:32:04" cr="2246" tx="PE23" user="01888329" estatus-tx="1" version="7.0.1001.2">
+    <data>
+        <xml-entrada>
+            <datos>
+                <transaccion id="PE80" tecla="00">
+                    <numclie>51372133</numclie>
+                </transaccion>
+            </datos>
+        </xml-entrada>
+        <trama-entrada>longer test string</trama-entrada>
+        <mq-server>MQ : SPIAWT99;;;SPIA.QC.QZT1;SPIA.QP.OUT</mq-server>
+        <direccion-IP>17.127.22.33</direccion-IP>
+        <nombre-servidor>Qpbxiaa</nombre-servidor>
+        <canal>ABC</canal>
+    </data>
+</root>

--- a/src/test/resources/054.xsd
+++ b/src/test/resources/054.xsd
@@ -1,0 +1,49 @@
+<?xml version = "1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="root">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="data" type="customdata"/>
+            </xs:sequence>
+            <xs:attribute type="xs:string"  name="date" use="required"/>
+            <xs:attribute type="xs:string"  name="cr" use="required"/>
+            <xs:attribute type="xs:string"  name="tx" use="required"/>
+            <xs:attribute type="xs:string"  name="user" use="required"/>
+            <xs:attribute type="xs:string"  name="estatus-tx" use="required"/>
+            <xs:attribute type="xs:string"  name="version" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="customdata">
+        <xs:sequence>
+            <xs:element name="xml-entrada" type="xmlentrada"/>
+            <xs:element name="trama-entrada" type="xs:string"/>
+            <xs:element name="mq-server" type="xs:string"/>
+            <xs:element name="direccion-IP" type="xs:string"/>
+            <xs:element name="nombre-servidor" type="xs:string"/>
+            <xs:element name="canal" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="xmlentrada">
+        <xs:sequence>
+            <xs:element name="datos" type="datos"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="datos">
+        <xs:sequence>
+            <xs:element name="transaccion" type="transaccion"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="transaccion">
+        <xs:sequence>
+            <xs:element name="numclie" type="xs:integer"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string"  name="id" use="required"/>
+        <xs:attribute type="xs:string"  name="tecla" use="required"/>
+    </xs:complexType>
+
+
+</xs:schema>


### PR DESCRIPTION
# Description

This commit modifies the Converter so that it now captures attributes from the root nodes of XML documents. The logic change for the Converter is relatively minor (read the attributes from the XML reader before starting to recursively traverse the document) so most of the changes in this commit are to add a few variations of test to verify the new behaviour.

Also updated dependencies to bring them up to date.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test
