### PR TITLE
fix: release job requires mq jar

### DIFF
--- a/.github/workflows/github-build-release.yml
+++ b/.github/workflows/github-build-release.yml
@@ -18,6 +18,18 @@ jobs:
         with:
           java-version: 17
           distribution: 'semeru'
+      - name: Download MQ Source Connector JAR
+        run: |
+          curl -L -o kafka-connect-mq-source-2.1.0.jar https://github.com/ibm-messaging/kafka-connect-mq-source/releases/download/v2.1.0/kafka-connect-mq-source-2.1.0.jar
+
+      - name: Install MQ Source Connector JAR in local Maven repository
+        run: |
+          mvn install:install-file \
+            -Dfile=kafka-connect-mq-source-2.1.0.jar \
+            -DgroupId=com.ibm.eventstreams.connect \
+            -DartifactId=kafka-connect-mq-source \
+            -Dversion=2.1.0 \
+            -Dpackaging=jar
       - name: Get java-version
         run: |
           BUILD_VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )


### PR DESCRIPTION
# Description

The release job is failing as its not able to pull the IBM MQ source jar. Fixed it by pulling the latest jar from MQ source release.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] E2E
- [ ] Unit Test
- [ ] Integration Test

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
