### PR TITLE
fix: format readme table and fix null pointer issue

### DIFF
--- a/.github/ISSUE_TEMPLATES/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATES/BUG_REPORT.yml
@@ -57,9 +57,9 @@ body:
       label: Version
       description: What version of our software are you running?
       options:
-        - 2.2.0 (Default)
-        - 1.5.2
-        - older (<1.5.2)
+        - latest
+        - 0.2.0
+        - older (<0.2.0)
     validations:
       required: true
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@ A Kafka Connect plugin to make it easier to work with XML data in Kafka Connect 
 
 ## Configuration
 
-Optional configuration that can be set when using the plugin to turn XML strings into Connect records
+Optional configuration that can be set when using the plugin to turn XML strings into Connect records (XML string -> Conect Record)
 
-| **Option**             | **Default value** | **Notes**                                                        |
-|------------------------|-------------------|------------------------------------------------------------------|
-| `root.element.name`    | `root`            | The name of the root element in the XML document being parsed.   |
-| `xsd.schema.path`      |                   | Location of a schema file to use to parse the XML string. |
-| `xml.doc.flat.enable`  | `false`           | Set to true if the XML strings contain a single value (e.g. `<root>the message</root>`) |
+| **Option**            | **Default value** | **Notes**                                                                               |
+| --------------------- | ----------------- | --------------------------------------------------------------------------------------- |
+| `root.element.name`   | `root`            | The name of the root element in the XML document being parsed.                          |
+| `xsd.schema.path`     |                   | Location of a schema file to use to parse the XML string.                               |
+| `xml.doc.flat.enable` | `false`           | Set to `true` if the XML strings contain a single value (e.g. `<root>the message</root>`) |
 
-Optional configuration that can be set when using the plugin to create XML strings from Connect records
+Optional configuration that can be set when using the plugin to create XML strings from Connect records (Conect Record -> XML string)
 
-| **Option**             | **Default value** | **Notes**                                                        |
-|------------------------|-------------------|------------------------------------------------------------------|
-| `root.element.name`    | `root`            | The name to use for the root element of the XML document being created. Only used when no name can be found within the schema of the Connect record. |
+| **Option**          | **Default value** | **Notes**                                                                                                                                            |
+| ------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `root.element.name` | `root`            | The name to use for the root element of the XML document being created. Only used when no name can be found within the schema of the Connect record. |
 
 ## Example uses
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.ibm.eventstreams.kafkaconnect.plugins</groupId>
     <artifactId>kafka-connect-xml-converter</artifactId>
     <description>Kafka Connect plugins for processing XML data</description>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
 
     <dependencies>
         <dependency>

--- a/src/main/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/engines/StructToXmlBytes.java
+++ b/src/main/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/engines/StructToXmlBytes.java
@@ -206,8 +206,11 @@ public class StructToXmlBytes extends ToXmlBytes {
             return;
         }
         for (final Field field : source.schema().fields()) {
-            final Schema fieldSchema = field.schema();
+            if (source.get(field) == null) {
+                continue;
+            }
 
+            final Schema fieldSchema = field.schema();
             switch (fieldSchema.type()) {
                 case ARRAY:
                     addArrayElements(doc, parentElement, source, field.name(), field.schema().valueSchema());

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlConverterSinkTest.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlConverterSinkTest.java
@@ -91,7 +91,9 @@ public class XmlConverterSinkTest {
             { "047", false, true, false },
             { "052", false, false, false },
             { "053", false, false, false },
-            { "054", false, true, false }
+            { "054", false, true, false },
+            { "055", false, false, false },
+            { "056", false, false, false }
         });
     }
 

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlConverterSourceTest.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlConverterSourceTest.java
@@ -92,7 +92,9 @@ public class XmlConverterSourceTest {
 //            { "040", true, true }
 //            { "043", true, true },
             { "044", false, false },
-            { "049", false, false }
+            { "049", false, false },
+            { "055", false, false },
+            { "056", false, false }
         });
     }
 

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlTransformationMapTest.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlTransformationMapTest.java
@@ -89,7 +89,9 @@ public class XmlTransformationMapTest {
             { "044", false },
             { "045", false },
             { "046", false },
-            { "049", false }
+            { "049", false },
+            { "055", false },
+            { "056", false }
         });
     }
 

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlTransformationStringTest.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlTransformationStringTest.java
@@ -78,7 +78,9 @@ public class XmlTransformationStringTest {
             { "037", false, false },
             { "052", true, true },
             { "053", true, true },
-            { "054", false, true }
+            { "054", false, true },
+            { "055", false, false },
+            { "056", false, false }
         });
     }
 

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlTransformationStructTest.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/XmlTransformationStructTest.java
@@ -92,7 +92,9 @@ public class XmlTransformationStructTest {
             { "044", false },
             { "046", false },
             { "048", false },
-            { "049", false }
+            { "049", false },
+            { "055", false },
+            { "056", false }
         });
     }
 

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/testutils/MapGenerators.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/testutils/MapGenerators.java
@@ -1028,6 +1028,14 @@ public class MapGenerators {
                 value.put("data", data);
                 break;
             }
+            case "055": {
+                value.put("message", "Hello World");
+                break;
+            }
+            case "056": {
+                value.put("message", "Hello World");
+                break;
+            }
         }
         return value;
     }

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/testutils/StructGenerators.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/testutils/StructGenerators.java
@@ -1811,6 +1811,34 @@ public class StructGenerators {
 
                 return new SchemaAndValue(schema, value);
             }
+            case "055": {
+                final Schema schema = SchemaBuilder.struct()
+                    .name("root")
+                    .field("message", Schema.STRING_SCHEMA)
+                    .field("optionallist", SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
+                    .build();
+
+                final Struct value = new Struct(schema);
+                value.put("message", "Hello World");
+
+                return new SchemaAndValue(schema, value);
+            }
+            case "056": {
+                final Schema innerSchema = SchemaBuilder.struct()
+                    .field("innermessage", Schema.STRING_SCHEMA)
+                    .build();
+
+                final Schema schema = SchemaBuilder.struct()
+                    .name("root")
+                    .field("message", Schema.STRING_SCHEMA)
+                    .field("optionallist", SchemaBuilder.array(innerSchema).optional().build())
+                    .build();
+
+                final Struct value = new Struct(schema);
+                value.put("message", "Hello World");
+
+                return new SchemaAndValue(schema, value);
+            }
         }
         throw new NotImplementedException("Unrecognised test " + testCaseId);
     }

--- a/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/testutils/StructGenerators.java
+++ b/src/test/java/com/ibm/eventstreams/kafkaconnect/plugins/xml/testutils/StructGenerators.java
@@ -413,7 +413,7 @@ public class StructGenerators {
             }
             case "008": {
                 final Schema value3Schema = SchemaBuilder.struct()
-                    .field("level2List1", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
+                    .field("level2List1", SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
                     .field("level2List2", SchemaBuilder.array(Schema.INT32_SCHEMA).build())
                     .build();
                 final Schema repeatingItemSchema = SchemaBuilder.struct()
@@ -455,7 +455,6 @@ public class StructGenerators {
                     .build();
 
                 final Struct value3Value = new Struct(value3Schema);
-                value3Value.put("level2List1", Collections.EMPTY_LIST);
                 value3Value.put("level2List2", List.of(10, 20, 30));
                 final Struct value2Item0 = new Struct(repeatingItemSchema);
                 value2Item0.put("level3Value6", "g");

--- a/src/test/resources/008-combined.json
+++ b/src/test/resources/008-combined.json
@@ -136,7 +136,7 @@
                             "type": "string",
                             "optional": false
                         },
-                        "optional": false,
+                        "optional": true,
                         "field": "level2List1"
                     },
                     {
@@ -179,7 +179,7 @@
             }
         },
         "level1Value3": {
-            "level2List1": [],
+            "level2List1": null,
             "level2List2": [
                 10,
                 20,

--- a/src/test/resources/055.xml
+++ b/src/test/resources/055.xml
@@ -1,0 +1,3 @@
+<root>
+    <message>Hello World</message>
+</root>

--- a/src/test/resources/055.xsd
+++ b/src/test/resources/055.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="root">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="message"      type="xs:string"/>
+                <xs:element name="optionallist" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/src/test/resources/056.xml
+++ b/src/test/resources/056.xml
@@ -1,0 +1,3 @@
+<root>
+    <message>Hello World</message>
+</root>

--- a/src/test/resources/056.xsd
+++ b/src/test/resources/056.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="root">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="message"      type="xs:string"/>
+                <xs:element name="optionallist" type="innerValue" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="innerValue">
+        <xs:sequence>
+            <xs:element name="innermessage" type="xs:string" />
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
# Description

- This PR trys to fix an issue with the converter that is causing the whole pipeline to fail. The issue is that when calling the method `addArrayElements` the source.getArray(field) call fails with null pointer exceptiong. This is happening because for a optional field (`phones`) in `source`. This can be easily recreated with the `loosehangerjeans` source connector.


```json
{
    "name": "kafka-datagen-xml",
    "config": {
        "connector.class": "com.ibm.eventautomation.demos.loosehangerjeans.DatagenSourceConnector",
        "tasks.max": "1",
        "key.converter": "org.apache.kafka.connect.storage.StringConverter",
        "key.converter.schemas.enable": "true",
        "value.converter": "com.ibm.eventstreams.kafkaconnect.plugins.xml.XmlConverter",
        "value.converter.schemas.enable": "true",
        "value.converter.xml.doc.flat.enable": "true"
    }
}
```

- This PR also formatts the tables in the readme.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] E2E
- [x] Unit Test
- [ ] Integration Test

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
