### PR TITLE
chore: bumping kafka version to 4.x

### DIFF
--- a/.github/workflows/checkstyle-and-tests.yml
+++ b/.github/workflows/checkstyle-and-tests.yml
@@ -20,15 +20,15 @@ jobs:
           distribution: 'semeru'
       - name: Download MQ Source Connector JAR
         run: |
-          curl -L -o kafka-connect-mq-source-2.1.0.jar https://github.com/ibm-messaging/kafka-connect-mq-source/releases/download/v2.1.0/kafka-connect-mq-source-2.1.0.jar
+          curl -L -o kafka-connect-mq-source-2.6.0.jar https://github.com/ibm-messaging/kafka-connect-mq-source/releases/download/v2.6.0/kafka-connect-mq-source-2.6.0.jar
 
       - name: Install MQ Source Connector JAR in local Maven repository
         run: |
           mvn install:install-file \
-            -Dfile=kafka-connect-mq-source-2.1.0.jar \
+            -Dfile=kafka-connect-mq-source-2.6.0.jar \
             -DgroupId=com.ibm.eventstreams.connect \
             -DartifactId=kafka-connect-mq-source \
-            -Dversion=2.1.0 \
+            -Dversion=2.6.0 \
             -Dpackaging=jar
       - name: Get java-version
         run: |

--- a/.github/workflows/github-build-release.yml
+++ b/.github/workflows/github-build-release.yml
@@ -20,15 +20,15 @@ jobs:
           distribution: 'semeru'
       - name: Download MQ Source Connector JAR
         run: |
-          curl -L -o kafka-connect-mq-source-2.1.0.jar https://github.com/ibm-messaging/kafka-connect-mq-source/releases/download/v2.1.0/kafka-connect-mq-source-2.1.0.jar
+          curl -L -o kafka-connect-mq-source-2.6.0.jar https://github.com/ibm-messaging/kafka-connect-mq-source/releases/download/v2.6.0/kafka-connect-mq-source-2.6.0.jar
 
       - name: Install MQ Source Connector JAR in local Maven repository
         run: |
           mvn install:install-file \
-            -Dfile=kafka-connect-mq-source-2.1.0.jar \
+            -Dfile=kafka-connect-mq-source-2.6.0.jar \
             -DgroupId=com.ibm.eventstreams.connect \
             -DartifactId=kafka-connect-mq-source \
-            -Dversion=2.1.0 \
+            -Dversion=2.6.0 \
             -Dpackaging=jar
       - name: Get java-version
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
     <groupId>com.ibm.eventstreams.kafkaconnect.plugins</groupId>
     <artifactId>kafka-connect-xml-converter</artifactId>
     <description>Kafka Connect plugins for processing XML data</description>
-    <version>0.2.1</version>
+    <version>0.2.2</version>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
-            <version>3.7.1</version>
+            <version>4.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.ibm.eventstreams.connect</groupId>
             <artifactId>kafka-connect-mq-source</artifactId>
-            <version>2.1.0</version>
+            <version>2.6.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-json</artifactId>
-            <version>3.7.1</version>
+            <version>4.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This pull request updates the `pom.xml` file to bring dependency versions up to date and bump the project version. The most important changes are version upgrades for both the project and its key dependencies.

Version upgrades:

* Updated the project version from `0.2.1` to `0.2.2` in `pom.xml` to indicate a new release.
* Upgraded `org.apache.kafka:connect-api` and `org.apache.kafka:connect-json` dependencies from version `3.7.1` to `4.0.0` for improved compatibility and features. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L11-R17) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L64-R64)
* Upgraded `com.ibm.eventstreams.connect:kafka-connect-mq-source` dependency from version `2.1.0` to `2.6.0` for bug fixes and new features.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] E2E
- [ ] Unit Test
- [ ] Integration Test

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
